### PR TITLE
Add support for POST callback for provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.2 (TBA)
+
+* Added support for POST callback from provider
+
 ## v0.4.1 (2019-10-08)
 
 * Use Assent `v0.1.2` and set `:redirect_uri` in config for OAuth 2.0 callback phase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## v0.4.2 (TBA)
 
-* Added support for POST callback from provider
+* Added support for POST callback from provider:
+  * Added `pow_assent_authorization_post_callback_routes/0` macro to `PowAssent.Phoenix.Router`
+  * Added `:skip_csrf_protection` pipeline example and scope with `pow_assent_authorization_post_callback_routes/0` call to the docs
+  * Use `Pow.Phoenix.Router` macros to dynamically filter duplicate routes
 
 ## v0.4.1 (2019-10-08)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ defmodule MyAppWeb.Router do
 
   # ...
 
+  pipeline :skip_csrf_protection do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+    plug :put_secure_browser_headers
+  end
+
+  # ...
+
+  scope "/" do
+    pipe_through :skip_csrf_protection
+
+    pow_assent_authorization_post_callback_routes()
+  end
+
   scope "/" do
     pipe_through [:browser]
     pow_routes()
@@ -114,11 +129,12 @@ end
 The following routes will now be available in your app:
 
 ```elixir
-pow_assent_authorization_path  GET     /auth/:provider/new          PowAssent.Phoenix.AuthorizationController :new
-pow_assent_authorization_path  DELETE  /auth/:provider              PowAssent.Phoenix.AuthorizationController :delete
-pow_assent_authorization_path  GET     /auth/:provider/callback     PowAssent.Phoenix.AuthorizationController :callback
-pow_assent_registration_path   GET     /auth/:provider/add-user-id  PowAssent.Phoenix.RegistrationController  :add_user_id
-pow_assent_registration_path   POST    /auth/:provider/create       PowAssent.Phoenix.RegistrationController  :create
+pow_assent_post_authorization_path  POST    /auth/:provider/callback     PowAssent.Phoenix.AuthorizationController :callback
+pow_assent_authorization_path       GET     /auth/:provider/new          PowAssent.Phoenix.AuthorizationController :new
+pow_assent_authorization_path       DELETE  /auth/:provider              PowAssent.Phoenix.AuthorizationController :delete
+pow_assent_authorization_path       GET     /auth/:provider/callback     PowAssent.Phoenix.AuthorizationController :callback
+pow_assent_registration_path        GET     /auth/:provider/add-user-id  PowAssent.Phoenix.RegistrationController  :add_user_id
+pow_assent_registration_path        POST    /auth/:provider/create       PowAssent.Phoenix.RegistrationController  :create
 ```
 
 Remember to run the new migrations with:
@@ -255,6 +271,21 @@ defmodule MyAppWeb.Router do
   use PowAssent.Phoenix.Router
 
   # ...
+
+  pipeline :skip_csrf_protection do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+    plug :put_secure_browser_headers
+  end
+
+  # ...
+
+  scope "/" do
+    pipe_through :skip_csrf_protection
+
+    pow_assent_authorization_post_callback_routes()
+  end
 
   scope "/" do
     pipe_through [:browser]

--- a/lib/pow_assent/phoenix/router.ex
+++ b/lib/pow_assent/phoenix/router.ex
@@ -53,6 +53,7 @@ defmodule PowAssent.Phoenix.Router do
       scope "/auth", PowAssent.Phoenix, as: "pow_assent" do
         resources "/:provider", AuthorizationController, singleton: true, only: [:new, :delete]
         get "/:provider/callback", AuthorizationController, :callback
+        post "/:provider/callback", AuthorizationController, :callback
       end
     end
   end

--- a/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
@@ -163,7 +163,10 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
   describe "POST /auth/:provider/callback" do
     setup %{conn: conn} do
-      conn = Plug.Conn.put_session(conn, :pow_assent_session_params, %{state: "token"})
+      conn =
+        conn
+        |> Plug.Conn.put_session(:pow_assent_session_params, %{state: "token"})
+        |> Plug.Conn.put_private(:plug_skip_csrf_protection, false)
 
       {:ok, conn: conn}
     end

--- a/test/support/phoenix/router.ex
+++ b/test/support/phoenix/router.ex
@@ -16,6 +16,19 @@ defmodule PowAssent.Test.Phoenix.Router do
     plug :put_secure_browser_headers
   end
 
+  pipeline :skip_csrf_protection do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+    plug :put_secure_browser_headers
+  end
+
+  scope "/" do
+    pipe_through :skip_csrf_protection
+
+    pow_assent_authorization_post_callback_routes()
+  end
+
   scope "/" do
     pipe_through :browser
 

--- a/test/support/phoenix/views.ex
+++ b/test/support/phoenix/views.ex
@@ -9,5 +9,6 @@ defmodule PowAssent.Test.Phoenix.ErrorView do
   @moduledoc false
   def render("500.html", _assigns), do: "500.html"
   def render("400.html", _assigns), do: "400.html"
+  def render("403.html", _assigns), do: "403.html"
   def render("404.html", _assigns), do: "404.html"
 end


### PR DESCRIPTION
Resolves #100 

Since CSRF would be triggered this also adds docs on how to skip CSRF protection just for the POST callback route.