### PR TITLE
Add support for request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.5 (TBA)
+
+* [`PowAssent.Phoenix.AuthorizationController`] Now supports `:request_path` param so the user will be redirected back to `:request_path` after successful authorization
+* [`PowAssent.Phoenix.ViewHelpers`] `PowAssent.Phoenix.ViewHelpers.authorization_link/2` now adds `:request_path` to the query param if assigned to the conn
+
 ## v0.4.4 (2019-11-22)
 
 **Note:** This release contains an important security fix.

--- a/lib/pow_assent/phoenix/views/view_helpers.ex
+++ b/lib/pow_assent/phoenix/views/view_helpers.ex
@@ -39,7 +39,7 @@ defmodule PowAssent.Phoenix.ViewHelpers do
   """
   @spec authorization_link(Conn.t(), atom()) :: HTML.safe()
   def authorization_link(conn, provider) do
-    query_params = authorization_link_query_params(conn)
+    query_params = invitation_token_query_params(conn) ++ request_path_query_params(conn)
 
     msg  = AuthorizationController.extension_messages(conn).login_with_provider(%{conn | params: %{"provider" => provider}})
     path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :new, [provider], query_params)
@@ -47,8 +47,11 @@ defmodule PowAssent.Phoenix.ViewHelpers do
     Link.link(msg, to: path)
   end
 
-  defp authorization_link_query_params(%{assigns: %{invited_user: %{invitation_token: token}}}), do: [invitation_token: token]
-  defp authorization_link_query_params(_conn), do: []
+  defp invitation_token_query_params(%{assigns: %{invited_user: %{invitation_token: token}}}), do: [invitation_token: token]
+  defp invitation_token_query_params(_conn), do: []
+
+  defp request_path_query_params(%{assigns: %{request_path: request_path}}), do: [request_path: request_path]
+  defp request_path_query_params(_conn), do: []
 
   @doc """
   Generates a provider deauthorization link.

--- a/test/pow_assent/phoenix/views/view_helpers_test.exs
+++ b/test/pow_assent/phoenix/views/view_helpers_test.exs
@@ -36,6 +36,15 @@ defmodule PowAssent.ViewHelpersTest do
     assert {:safe, iodata} == Link.link("Remove Test provider authentication", to: "/auth/test_provider", method: "delete")
   end
 
+  test "provider_links/1 with request_path", %{conn: conn} do
+    [safe: iodata] =
+      conn
+      |> Conn.assign(:request_path, "/custom-url")
+      |> ViewHelpers.provider_links()
+
+    assert {:safe, iodata} == Link.link("Sign in with Test provider", to: "/auth/test_provider/new?request_path=%2Fcustom-url")
+  end
+
   test "provider_links/1 with invited_user", %{conn: conn} do
     conn = PowInvitation.Plug.assign_invited_user(conn, %PowAssent.Test.Invitation.Users.User{invitation_token: "token"})
 

--- a/test/support/phoenix/routes.ex
+++ b/test/support/phoenix/routes.ex
@@ -2,6 +2,8 @@ defmodule PowAssent.Test.Phoenix.Routes do
   @moduledoc false
   use Pow.Phoenix.Routes
 
+  def after_sign_in_path(%{assigns: %{request_path: request_path}}) when is_binary(request_path),
+    do: request_path
   def after_sign_in_path(_conn), do: "/session_created"
 
   def after_registration_path(_conn), do: "/registration_created"


### PR DESCRIPTION
Resolves #109 

This adds support for request path. In session new template, when the `PowAssent.ViewHelpers.provider_links/1` or `PowAssent.ViewHelpers.authorization_link/2` is used, the assigned `:request_path` will be carried over to the authorization URLs just like in Pow with the create path. The request path will be temporarily stored in the session, and deleted as soon as the user returns for the callback.