### PR TITLE
Permit link opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v0.4.5 (TBA)
 
 * [`PowAssent.Phoenix.AuthorizationController`] Now supports `:request_path` param so the user will be redirected back to `:request_path` after successful authorization
-* [`PowAssent.Phoenix.ViewHelpers`] `PowAssent.Phoenix.ViewHelpers.authorization_link/2` now adds `:request_path` to the query param if assigned to the conn
+* [`PowAssent.Phoenix.ViewHelpers`] `PowAssent.Phoenix.ViewHelpers.authorization_link/3` now adds `:request_path` to the query param if assigned to the conn
+* [`PowAssent.Phoenix.ViewHelpers`] `PowAssent.Phoenix.ViewHelpers.authorization_link/3`, `PowAssent.Phoenix.ViewHelpers.deauthorization_link/3`, and `PowAssent.Phoenix.ViewHelpers.provider_links/2` now accepts keyword list with options to be passed on to the link generation
 
 ## v0.4.4 (2019-11-22)
 

--- a/test/pow_assent/phoenix/views/view_helpers_test.exs
+++ b/test/pow_assent/phoenix/views/view_helpers_test.exs
@@ -36,6 +36,12 @@ defmodule PowAssent.ViewHelpersTest do
     assert {:safe, iodata} == Link.link("Remove Test provider authentication", to: "/auth/test_provider", method: "delete")
   end
 
+  test "provider_links/1 with link opts", %{conn: conn} do
+    [safe: iodata] = ViewHelpers.provider_links(conn, class: "example")
+
+    assert {:safe, iodata} == Link.link("Sign in with Test provider", to: "/auth/test_provider/new", class: "example")
+  end
+
   test "provider_links/1 with request_path", %{conn: conn} do
     [safe: iodata] =
       conn


### PR DESCRIPTION
Resolves #111 

This permits link options to be passed on using `PowAssent.Phoenix.ViewHelpers.authorization_link/3`, `PowAssent.Phoenix.ViewHelpers.deauthorization_link/3`, and `PowAssent.Phoenix.ViewHelpers.provider_links/2`.