### PR TITLE
Cast user params when showing `:add_user_id` page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [`PowAssent.Plug`] Added `PowAssent.Plug.change_user/4`
 * [`PowAssent.Operations`] Added `PowAssent.Operations.user_identity_changeset/4`
+* [`PowAssent.Phoenix.RegistrationController`] Now casts the user params fetched from the provider in the changeset in `PowAssent.Phoenix.RegistrationController.process_add_user_id/2`
 
 ## v0.4.5 (2019-12-06)
 

--- a/lib/pow_assent/phoenix/controllers/registration_controller.ex
+++ b/lib/pow_assent/phoenix/controllers/registration_controller.ex
@@ -10,8 +10,8 @@ defmodule PowAssent.Phoenix.RegistrationController do
   plug :assign_create_path
 
   @spec process_add_user_id(Conn.t(), map()) :: {:ok, map(), Conn.t()}
-  def process_add_user_id(conn, _params) do
-    {:ok, Plug.change_user(conn), conn}
+  def process_add_user_id(%{private: %{pow_assent_params: %{user: user_params}}} = conn, _params) do
+    {:ok, Plug.change_user(conn, %{}, user_params), conn}
   end
 
   @spec respond_add_user_id({:ok, map(), Conn.t()}) :: Conn.t()

--- a/test/pow_assent/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/registration_controller_test.exs
@@ -38,6 +38,18 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
       assert html =~ "<label for=\"user_email\">Email</label>"
       assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\">"
     end
+
+    test "shows with prefill user id", %{conn: conn} do
+      provider_params = %{@provider => %{user_identity: @user_identity_params, user: Map.put(@user_params, "email", "taken@example.com")}}
+      conn =
+        conn
+        |> Plug.Conn.put_session(:pow_assent_params, provider_params)
+        |> get(Routes.pow_assent_registration_path(conn, :add_user_id, @provider))
+
+      assert html = html_response(conn, 200)
+      assert html =~ "<label for=\"user_email\">Email</label>"
+      assert html =~ "<input id=\"user_email\" name=\"user[email]\" type=\"text\" value=\"taken@example.com\">"
+    end
   end
 
   describe "POST /auth/:provider/create" do


### PR DESCRIPTION
As discussed in https://github.com/pow-auth/pow_assent/issues/113 this will cast the user params in the changeset for the `:add_user_id` route. This makes sense since anyway the same user params are casted in when the `:create` route is called.

I should probably create a dedicated `PowAssent.Plug.change_user/2` method and handle the user params there so it works the same way as `PowAssent.Plug.create_user/4` method call.