### PR TITLE
Use `user_identity_changeset/4` instead of default `changeset/2` in registration controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.6 (TBA)
+
+### Enhancements
+
+* [`PowAssent.Plug`] Added `PowAssent.Plug.change_user/2`
+* [`PowAssent.Operations`] Added `PowAssent.Operations.user_identity_changeset/4`
+
 ## v0.4.5 (2019-12-06)
 
 * [`PowAssent.Phoenix.AuthorizationController`] Now supports `:request_path` param so the user will be redirected back to `:request_path` after successful authorization

--- a/lib/pow_assent/operations.ex
+++ b/lib/pow_assent/operations.ex
@@ -7,6 +7,7 @@ defmodule PowAssent.Operations do
   is passed in the configuration.
   """
   alias PowAssent.{Config, Ecto.UserIdentities.Context}
+  alias Pow.Config, as: PowConfig
 
   @doc """
   Retrieve a user with the strategy provider name and uid.
@@ -54,6 +55,21 @@ defmodule PowAssent.Operations do
       Context -> Context.create_user(user_identity_params, user_params, user_id_params, config)
       module  -> module.create_user(user_identity_params, user_params, user_id_params)
     end
+  end
+
+  @doc """
+  Build a changeset from a blank user struct.
+
+  It'll use the schema module fetched from the config through
+  `Pow.Config.user!/1` and call `user_identity_changeset/4` on it.
+  """
+  @spec user_identity_changeset(map(), map(), map(), Config.t()) :: map() | nil
+  def user_identity_changeset(params, user_params, user_id_params, config) do
+    user_mod = PowConfig.user!(config)
+
+    user_mod
+    |> struct()
+    |> user_mod.user_identity_changeset(params, user_params, user_id_params)
   end
 
   @doc """

--- a/lib/pow_assent/phoenix/controllers/registration_controller.ex
+++ b/lib/pow_assent/phoenix/controllers/registration_controller.ex
@@ -11,7 +11,7 @@ defmodule PowAssent.Phoenix.RegistrationController do
 
   @spec process_add_user_id(Conn.t(), map()) :: {:ok, map(), Conn.t()}
   def process_add_user_id(conn, _params) do
-    {:ok, Pow.Plug.change_user(conn), conn}
+    {:ok, Plug.change_user(conn), conn}
   end
 
   @spec respond_add_user_id({:ok, map(), Conn.t()}) :: Conn.t()

--- a/lib/pow_assent/plug.ex
+++ b/lib/pow_assent/plug.ex
@@ -172,6 +172,16 @@ defmodule PowAssent.Plug do
   end
 
   @doc """
+  Creates a changeset.
+  """
+  @spec change_user(Conn.t(), map()) :: map()
+  def change_user(conn, params \\ %{}, user_params \\ %{}, user_id_params \\ %{}) do
+    config = fetch_config(conn)
+
+    Operations.user_identity_changeset(params, user_params, user_id_params, config)
+  end
+
+  @doc """
   Deletes the associated user identity for the current user and provider.
   """
   @spec delete_identity(Conn.t(), binary()) :: {:ok, map(), Conn.t()} | {:error, {:no_password, map()}, Conn.t()}


### PR DESCRIPTION
Prompted by #114