### PR TITLE
Refactor callback handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [`PowAssent.Operations`] Added `PowAssent.Operations.user_identity_changeset/4`
 * [`PowAssent.Phoenix.AuthorizationController`] Now prevents user enumeration attack using `PowEmailConfirmation.Phoenix.ControllerCallbacks` when `PowEmailConfirmation` extension is enabled
 [`PowAssent.Phoenix.RegistrationController`] Now prevents user enumeration attack using `PowEmailConfirmation.Phoenix.ControllerCallbacks` when `PowEmailConfirmation` extension is enabled
+* [`PowAssent.Plug`] Moved business logic away from `PowAssent.Phoenix.AuthorizationController` into `PowAssent.Plug.callback_upsert/4` that will authenticate, upsert user identity, or create user
 
 ## Bug fixes
 

--- a/lib/pow_assent/phoenix/controllers/authorization_controller.ex
+++ b/lib/pow_assent/phoenix/controllers/authorization_controller.ex
@@ -43,8 +43,8 @@ defmodule PowAssent.Phoenix.AuthorizationController do
     conn
     |> load_session_params()
     |> maybe_assign_invited_user()
-    |> Plug.callback(provider, params, conn.assigns.callback_url)
-    |> upsert_identity_or_authenticate_or_create_user()
+    |> Conn.put_private(:pow_assent_registration, Map.get(conn.private, :pow_assent_registration, registration_path?(conn)))
+    |> Plug.callback_upsert(provider, params, conn.assigns.callback_url)
   end
 
   defp load_session_params(conn) do
@@ -61,141 +61,98 @@ defmodule PowAssent.Phoenix.AuthorizationController do
   end
   defp maybe_assign_invited_user(conn), do: conn
 
-  defp upsert_identity_or_authenticate_or_create_user({:ok, user_identity_params, user_params, conn}) do
-    case Pow.Plug.current_user(conn) do
-      nil   -> authenticate_or_create_user(conn, user_identity_params, user_params)
-      _user -> upsert_user_identity(conn, user_identity_params)
-    end
-  end
-  defp upsert_identity_or_authenticate_or_create_user({:error, error, _conn}), do: handle_strategy_error(error)
-
-  defp upsert_user_identity(conn, user_identity_params) do
-    conn
-    |> Plug.upsert_identity(user_identity_params)
-    |> case do
-      {:ok, _user, conn}    -> {:ok, conn}
-      {:error, error, conn} -> {:error, error, conn}
-    end
-  end
-
-  defp authenticate_or_create_user(conn, user_identity_params, user_params) do
-    case Plug.authenticate(conn, user_identity_params) do
-      {:ok, conn}    -> upsert_user_identity(conn, user_identity_params)
-      {:error, conn} -> create_user(conn, user_identity_params, user_params)
-    end
-  end
-
-  defp create_user(conn, user_identity_params, user_params) do
-    conn = Conn.put_private(conn, :pow_assent_action, :registration)
-
-    case registration_path?(conn) do
-      true  -> do_create_user(conn, user_identity_params, user_params)
-      false -> {:error, conn}
-    end
-  end
-
   defp registration_path?(conn) do
     [conn.private.phoenix_router, Helpers]
     |> Module.concat()
     |> function_exported?(:pow_assent_registration_path, 3)
   end
 
-  defp do_create_user(conn, user_identity_params, user_params) do
-    case Plug.create_user(conn, user_identity_params, user_params) do
-      {:ok, _user, conn} ->
-        {:ok, conn}
-
-      {:error, changeset, conn} ->
-        conn = Conn.put_private(conn, :pow_assent_params, %{user_identity: user_identity_params, user: user_params})
-
-        {:error, changeset, conn}
-    end
-  end
-
   @spec respond_callback({:ok, Conn.t()} | {:error, Conn.t()} | {:error, {atom(), map()} | map(), Conn.t()}) :: Conn.t()
-  def respond_callback({:ok, %{private: %{pow_assent_action: :registration}}} = resp) do
-    maybe_trigger_email_confirmed_controller_callback(resp, fn {:ok, conn} ->
+  def respond_callback({:ok, %{private: %{pow_assent_callback_state: {:ok, :create_user}}} = conn}) do
+    trigger_registration_email_confirmation_controller_callback(conn, fn conn ->
       conn
       |> put_flash(:info, extension_messages(conn).user_has_been_created(conn))
       |> redirect(to: routes(conn).after_registration_path(conn))
     end)
   end
-  def respond_callback({:ok, _conn} = resp) do
-    maybe_trigger_email_confirmed_controller_callback(resp, fn {:ok, conn} ->
+  def respond_callback({:ok, conn}) do
+    trigger_session_email_confirmation_controller_callback(conn, fn conn ->
       conn
       |> put_flash(:info, extension_messages(conn).signed_in(conn))
       |> redirect(to: routes(conn).after_sign_in_path(conn))
     end)
   end
-  def respond_callback({:error, {:bound_to_different_user, _changeset}, conn}) do
+  def respond_callback({:error, %{private: %{pow_assent_callback_state: {:error, :strategy}, pow_assent_callback_error: error}}}),
+    do: handle_strategy_error(error)
+  def respond_callback({:error, %{private: %{pow_assent_callback_error: {:bound_to_different_user, _changeset}}} = conn}) do
     conn
     |> put_flash(:error, extension_messages(conn).account_already_bound_to_other_user(conn))
     |> redirect(to: routes(conn).session_path(conn, :new))
   end
-  def respond_callback({:error, {:invalid_user_id_field, changeset}, %{params: %{"provider" => provider}, private: %{pow_assent_params: params}} = conn}) do
-    maybe_trigger_email_confirmed_controller_callback({:error, changeset, conn}, fn {:error, _changeset, conn} ->
+  def respond_callback({:error, %{private: %{pow_assent_callback_error: {:invalid_user_id_field, _changeset}}} = conn}) do
+    trigger_registration_email_confirmation_controller_callback(conn, fn conn ->
+      params   = Map.fetch!(conn.private, :pow_assent_callback_params)
+      provider = Map.fetch!(conn.params, "provider")
+
       conn
-      |> Conn.put_session(:pow_assent_params, %{provider => params})
-      |> redirect(to: routes(conn).path_for(conn, RegistrationController, :add_user_id, [conn.params["provider"]]))
+      |> Conn.put_session(:pow_assent_callback_params, %{provider => params})
+      |> redirect(to: routes(conn).path_for(conn, RegistrationController, :add_user_id, [provider]))
     end)
   end
-  def respond_callback({:error, _changeset, conn}),
-    do: respond_callback({:error, conn})
   def respond_callback({:error, conn}) do
     conn
     |> put_flash(:error, extension_messages(conn).could_not_sign_in(conn))
     |> redirect(to: routes(conn).session_path(conn, :new))
   end
 
-  defp maybe_trigger_email_confirmed_controller_callback({:ok, conn} = resp, callback) do
-    config = PowPlug.fetch_config(conn)
-    type   = conn.private[:pow_assent_action]
+  defp trigger_registration_email_confirmation_controller_callback(conn, callback) do
+    config        = PowPlug.fetch_config(conn)
+    %{user: user} = conn.private[:pow_assent_callback_params]
 
-    maybe_trigger_email_confirmed_controller_callback(resp, type, callback, config)
-  end
-  defp maybe_trigger_email_confirmed_controller_callback({:error, _changeset, %{private: %{pow_assent_params: params}} = conn} = resp, callback) do
-    config   = PowPlug.fetch_config(conn)
-    type     = conn.private[:pow_assent_action]
+    cond do
+      email_verified?(user) ->
+        callback.(conn)
 
-    case email_verified?(params[:user]) do
-      true  -> callback.(resp)
-      false -> maybe_trigger_email_confirmed_controller_callback(resp, type, callback, config)
+      email_confirmation_enabled?(config) ->
+        Pow.Phoenix.RegistrationController
+        |> EmailConfirmationCallbacks.before_respond(:create, to_email_confirmation_res(conn), config)
+        |> case do
+          {:ok, _user, conn}         -> callback.(conn)
+          {:error, _changeset, conn} -> callback.(conn)
+          {:halt, conn}              -> conn
+        end
+
+      true ->
+        callback.(conn)
     end
   end
-  defp maybe_trigger_email_confirmed_controller_callback(resp, type, callback, config) do
-    config
-    |> ExtensionConfig.extensions()
-    |> Enum.member?(PowEmailConfirmation)
-    |> case do
-      true  -> trigger_email_confirmed_controller_callback(resp, type, config)
-      false -> resp
-    end
-    |> case do
-      {:halt, conn} -> conn
-      resp          -> callback.(resp)
-    end
+
+  defp to_email_confirmation_res(%{private: %{pow_assent_callback_state: {:error, _method}, pow_assent_callback_error: {_type, changeset}}} = conn) do
+    {:error, changeset, conn}
+  end
+  defp to_email_confirmation_res(%{private: %{pow_assent_callback_state: {:ok, _method}}} = conn) do
+    {:ok, PowPlug.current_user(conn), conn}
   end
 
   defp email_verified?(%{"email_verified" => true}), do: true
   defp email_verified?(%{email_verified: true}), do: true
   defp email_verified?(_params), do: false
 
-  defp trigger_email_confirmed_controller_callback(resp, :registration, config) do
-    resp =
-      case resp do
-        {:ok, conn} -> {:ok, PowPlug.current_user(conn), conn}
-        resp        -> resp
-      end
-
-    Pow.Phoenix.RegistrationController
-    |> EmailConfirmationCallbacks.before_respond(:create, resp, config)
-    |> case do
-      {:ok, _user, conn} -> {:ok, conn}
-      resp               -> resp
-    end
+  defp email_confirmation_enabled?(config) do
+    config
+    |> ExtensionConfig.extensions()
+    |> Enum.member?(PowEmailConfirmation)
   end
-  defp trigger_email_confirmed_controller_callback(resp, _type, config) do
-    EmailConfirmationCallbacks.before_respond(Pow.Phoenix.SessionController, :create, resp, config)
+
+  defp trigger_session_email_confirmation_controller_callback(conn, callback) do
+    config = PowPlug.fetch_config(conn)
+
+    Pow.Phoenix.SessionController
+    |> EmailConfirmationCallbacks.before_respond(:create, {:ok, conn}, config)
+    |> case do
+      {:ok, conn}   -> callback.(conn)
+      {:halt, conn} -> conn
+    end
   end
 
   @spec process_delete(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, any(), Conn.t()}

--- a/lib/pow_assent/phoenix/controllers/registration_controller.ex
+++ b/lib/pow_assent/phoenix/controllers/registration_controller.ex
@@ -24,13 +24,13 @@ defmodule PowAssent.Phoenix.RegistrationController do
   end
 
   @spec process_create(Conn.t(), map()) :: {:ok, map(), Conn.t()} | {:error, map(), Conn.t()}
-  def process_create(%{private: %{pow_assent_params: %{user_identity: user_identity_params, user: user_params}}} = conn, %{"user" => user_id_params}) do
+  def process_create(%{private: %{pow_assent_callback_params: %{user_identity: user_identity_params, user: user_params}}} = conn, %{"user" => user_id_params}) do
     Plug.create_user(conn, user_identity_params, user_params, user_id_params)
   end
 
   @spec respond_create({:ok, map(), Conn.t()} | {:error, map(), Conn.t()}) :: Conn.t()
   def respond_create({:ok, user, conn}) do
-    conn =  Conn.delete_session(conn, :pow_assent_params)
+    conn =  Conn.delete_session(conn, :pow_assent_callback_params)
 
     maybe_trigger_email_confirmed_controller_callback({:ok, user, conn}, fn {:ok, _user, conn} ->
       conn
@@ -78,8 +78,8 @@ defmodule PowAssent.Phoenix.RegistrationController do
 
   defp load_params_from_session(%{params: %{"provider" => provider}, private: %{plug_session: plug_session}} = conn, _opts) do
     case plug_session do
-      %{"pow_assent_params" => %{^provider => params}} ->
-        Conn.put_private(conn, :pow_assent_params, params)
+      %{"pow_assent_callback_params" => %{^provider => params}} ->
+        Conn.put_private(conn, :pow_assent_callback_params, params)
 
       _ ->
         conn

--- a/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
@@ -149,7 +149,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = get conn, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params)
 
       assert redirected_to(conn) == Routes.pow_assent_registration_path(conn, :add_user_id, "test_provider")
-      assert %{"test_provider" => %{user_identity: user_identity, user: user}} = Conn.get_session(conn, :pow_assent_params)
+      assert %{"test_provider" => %{user_identity: user_identity, user: user}} = Conn.get_session(conn, :pow_assent_callback_params)
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => ""}
       refute Conn.get_session(conn, :pow_assent_session_params)
@@ -161,7 +161,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = get conn, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params)
 
       assert redirected_to(conn) == Routes.pow_assent_registration_path(conn, :add_user_id, "test_provider")
-      assert %{"test_provider" => %{user_identity: user_identity, user: user}} = Conn.get_session(conn, :pow_assent_params)
+      assert %{"test_provider" => %{user_identity: user_identity, user: user}} = Conn.get_session(conn, :pow_assent_callback_params)
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => "taken@example.com"}
       refute Conn.get_session(conn, :pow_assent_session_params)
@@ -259,7 +259,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = Phoenix.ConnTest.dispatch(conn, EmailConfirmationEndpoint, :get, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params))
 
       assert redirected_to(conn) == Routes.pow_assent_registration_path(conn, :add_user_id, "test_provider")
-      assert %{"test_provider" => %{user_identity: user_identity, user: user}} = Conn.get_session(conn, :pow_assent_params)
+      assert %{"test_provider" => %{user_identity: user_identity, user: user}} = Conn.get_session(conn, :pow_assent_callback_params)
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => "taken@example.com", "email_verified" => true}
       refute Conn.get_session(conn, :pow_assent_session_params)

--- a/test/pow_assent/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/registration_controller_test.exs
@@ -16,7 +16,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
   end
 
   setup %{conn: conn} do
-    conn = Conn.put_session(conn, :pow_assent_params, provider_params())
+    conn = Conn.put_session(conn, :pow_assent_callback_params, provider_params())
 
     {:ok, conn: conn}
   end
@@ -25,7 +25,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with missing session params", %{conn: conn} do
       conn =
         conn
-        |> Conn.delete_session(:pow_assent_params)
+        |> Conn.delete_session(:pow_assent_callback_params)
         |> get(Routes.pow_assent_registration_path(conn, :add_user_id, @provider))
 
       assert redirected_to(conn) == "/logged-out"
@@ -55,7 +55,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with missing session params", %{conn: conn} do
       conn =
         conn
-        |> Conn.delete_session(:pow_assent_params)
+        |> Conn.delete_session(:pow_assent_callback_params)
         |> post(Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
       assert redirected_to(conn) == "/logged-out"
@@ -84,7 +84,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
       params = provider_params(user_identity_params: %{"uid" => "identity_taken"})
       conn   =
         conn
-        |> Conn.put_session(:pow_assent_params, params)
+        |> Conn.put_session(:pow_assent_callback_params, params)
         |> post(Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :new)


### PR DESCRIPTION
Resolves #131

Some thoughts before merging this:

- Email verification key should maybe be done in `PowAssent.Plug.callback_upsert/4` also and set as a private key like `pow_assent_callback_email_verified: true`
- Maybe deprecate direct calls to `callback/4` and move to rename methods in `v0.5.0`
- Remove special error cases of `{:bound_to_different_user, changeset}` and `{:invalid_user_id_field, changeset}` and let controller/plug handle it similar to [`Pow.Plug.__prevent_information_leak__ /2`](https://github.com/danschultzer/pow/blob/c404d03e480bbf008cb3c914e812d4cfd8ae65ad/lib/pow/plug.ex#L201-L212)
- Add test cases for `PowAssent.Plug.callback_upsert/4`