### PR TITLE
Refactor session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.4.6 (TBA)
 
+The callback flow has been changed so sessions are now stored in the backend cache with `PowAssent.Store.Session` instead of using `Plug.Session`. This prevents exposure of sensitive data, as the only thing stored in the Plug session is a random UUID.
+
 ### Enhancements
 
 * [`PowAssent.Plug`] Added `PowAssent.Plug.change_user/4`
@@ -9,6 +11,10 @@
 * [`PowAssent.Phoenix.AuthorizationController`] Now prevents user enumeration attack using `PowEmailConfirmation.Phoenix.ControllerCallbacks` when `PowEmailConfirmation` extension is enabled
 [`PowAssent.Phoenix.RegistrationController`] Now prevents user enumeration attack using `PowEmailConfirmation.Phoenix.ControllerCallbacks` when `PowEmailConfirmation` extension is enabled
 * [`PowAssent.Plug`] Moved business logic away from `PowAssent.Phoenix.AuthorizationController` into `PowAssent.Plug.callback_upsert/4` that will authenticate, upsert user identity, or create user
+* [`PowAssent.Store.Session`] Added session store module
+* [`PowAssent.Plug`] Added `PowAssent.Plug.init_session/1`
+* [`PowAssent.Plug`] Added `PowAssent.Plug.put_session/3`
+* [`PowAssent.Plug`] Added `PowAssent.Plug.delete_session/2`
 
 ## Bug fixes
 

--- a/lib/pow_assent/plug.ex
+++ b/lib/pow_assent/plug.ex
@@ -15,8 +15,8 @@ defmodule PowAssent.Plug do
         ]
   """
   alias Plug.Conn
-  alias PowAssent.{Config, Operations}
-  alias Pow.Plug
+  alias PowAssent.{Config, Operations, Store.Session}
+  alias Pow.{Plug, Store.Backend.EtsCache, UUID}
 
   @doc """
   Calls the authorize_url method for the provider strategy.
@@ -385,30 +385,78 @@ defmodule PowAssent.Plug do
   end
 
   @private_session_key :pow_assent_session
+  @private_session_info_key :pow_assent_session_info
 
   @doc """
   Initializes session.
+
+  Session data will be fetched and deleted from the PowAssent session store if
+  a `pow_assent_session` key was found in the Plug session. The session data is
+  set for the `:pow_assent_session` key in in `conn.private`.
+
+  A `:before_send` callback will be set to store session data. If
+  `:pow_assent_session` key in `conn.private` has been populated, a random UUID
+  is generated and used as the key for the stored session data. The UUID is
+  then stored as `pow_assent_session` key in the Plug session.
+
+  The session store can be changed by setting `:session_store` config option.
+  By default it's
+  `{PowAssent.Store.Session, backend: Pow.Store.Backend.EtsCache}`. The backend
+  store can be changed by setting `:cache_store_backend` for the Pow
+  configuration.
   """
   @spec init_session(Conn.t()) :: Conn.t()
   def init_session(conn) do
-    session_key = Atom.to_string(@private_session_key)
-    value =
-      case Conn.get_session(conn) do
-        %{^session_key => session} -> session
-        _                          -> Map.get(conn.private, @private_session_key, %{})
-      end
+    config     = fetch_config(conn)
+    pow_config = Plug.fetch_config(conn)
+    key        = Conn.get_session(conn, @private_session_key)
+    value      = get_session_value(key, config, pow_config) || default_value(conn)
 
     conn
+    |> Conn.delete_session(@private_session_key)
     |> Conn.put_private(@private_session_key, value)
-    |> Conn.register_before_send(fn conn ->
-      conn.private
-      |> Map.get(@private_session_key)
-      |> case do
-        nil   -> conn
-        value -> Conn.put_session(conn, session_key, value)
-      end
-    end)
+    |> Conn.register_before_send(& put_session_value(&1, config, pow_config))
   end
+
+  defp default_value(%{private: %{@private_session_key => session}}), do: session
+  defp default_value(_conn), do: %{}
+
+  defp get_session_value(nil, _config, _pow_config), do: nil
+  defp get_session_value(key, config, pow_config) do
+    {store, store_config} = store(config, pow_config)
+
+    case store.get(store_config, key) do
+      :not_found ->
+        nil
+
+      value ->
+        store.delete(store_config, key)
+        value
+    end
+  end
+
+  defp store(config, pow_config) do
+    case Config.get(config, :session_store, default_store(pow_config)) do
+      {store, store_config} -> {store, store_config}
+      store                 -> {store, []}
+    end
+  end
+
+  defp default_store(pow_config) do
+    backend = Config.get(pow_config, :cache_store_backend, EtsCache)
+
+    {Session, [backend: backend]}
+  end
+
+  defp put_session_value(%{private: %{@private_session_info_key => :write, @private_session_key => session}} = conn, config, pow_config) when session != %{} do
+    {store, store_config} = store(config, pow_config)
+    key                   = UUID.generate()
+
+    store.put(store_config, key, session)
+
+    Conn.put_session(conn, @private_session_key, key)
+  end
+  defp put_session_value(conn, _config, _pow_config), do: conn
 
   @doc """
   Inserts value for key in session.
@@ -417,7 +465,9 @@ defmodule PowAssent.Plug do
   def put_session(%{private: %{@private_session_key => session}} = conn, key, value) do
     session = Map.put(session, key, value)
 
-    Conn.put_private(conn, @private_session_key, session)
+    conn
+    |> Conn.put_private(@private_session_key, session)
+    |> Conn.put_private(@private_session_info_key, :write)
   end
 
   @doc """

--- a/lib/pow_assent/store/session.ex
+++ b/lib/pow_assent/store/session.ex
@@ -1,0 +1,8 @@
+defmodule PowAssent.Store.Session do
+  @moduledoc """
+  Default module for session storage.
+  """
+  use Pow.Store.Base,
+    ttl: :timer.minutes(5),
+    namespace: "pow_assent_sessions"
+end

--- a/test/pow_assent/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/registration_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule PowAssent.Phoenix.RegistrationControllerTest do
   use PowAssent.Test.Phoenix.ConnCase
 
-  alias PowAssent.Plug
+  alias Plug.Conn
 
   @provider "test_provider"
   @token_params %{"access_token" => "access_token"}
@@ -9,10 +9,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
   @user_params %{"name" => "John Doe"}
 
   setup %{conn: conn} do
-    conn =
-      conn
-      |> Plug.init_session()
-      |> Plug.put_session(:callback_params, provider_params())
+    conn = Conn.put_private(conn, :pow_assent_session, %{callback_params: provider_params()})
 
     {:ok, conn: conn}
   end
@@ -21,7 +18,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with missing session params", %{conn: conn} do
       conn =
         conn
-        |> Plug.delete_session(:callback_params)
+        |> Conn.put_private(:pow_assent_session, nil)
         |> get(Routes.pow_assent_registration_path(conn, :add_user_id, @provider))
 
       assert redirected_to(conn) == "/logged-out"
@@ -51,7 +48,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with missing session params", %{conn: conn} do
       conn =
         conn
-        |> Plug.delete_session(:callback_params)
+        |> Conn.put_private(:pow_assent_session, nil)
         |> post(Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
       assert redirected_to(conn) == "/logged-out"
@@ -80,7 +77,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
       params = provider_params(user_identity_params: %{"uid" => "identity_taken"})
       conn   =
         conn
-        |> Plug.put_session(:callback_params, params)
+        |> Conn.put_private(:pow_assent_session, %{callback_params: params})
         |> post(Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :new)

--- a/test/support/ets_cache_mock.ex
+++ b/test/support/ets_cache_mock.ex
@@ -1,0 +1,44 @@
+defmodule PowAssent.Test.EtsCacheMock do
+  @moduledoc false
+  @tab __MODULE__
+
+  def init, do: :ets.new(@tab, [:ordered_set, :protected, :named_table])
+
+  def get(config, key) do
+    ets_key = ets_key(config, key)
+
+    @tab
+    |> :ets.lookup(ets_key)
+    |> case do
+      [{^ets_key, value} | _rest] -> value
+      []                          -> :not_found
+    end
+  end
+
+  def delete(config, key) do
+    :ets.delete(@tab, ets_key(config, key))
+
+    :ok
+  end
+
+  def put(config, record_or_records) do
+    records     = List.wrap(record_or_records)
+    ets_records = Enum.map(records, fn {key, value} ->
+      {ets_key(config, key), value}
+    end)
+
+    :ets.insert(@tab, ets_records)
+  end
+
+  def all(config, match) do
+    ets_key_match = ets_key(config, match)
+
+    @tab
+    |> :ets.select([{{ets_key_match, :_}, [], [:"$_"]}])
+    |> Enum.map(fn {[_namespace | keys], value} -> {keys, value} end)
+  end
+
+  defp ets_key(config, key) do
+    [Keyword.get(config, :namespace, "cache")] ++ List.wrap(key)
+  end
+end


### PR DESCRIPTION
Resolves #134 

`PowAssent.Store.Session` is now used to store the session data instead of `Plug.Session`.