### PR TITLE
Store changeset and use when rendering `add_user_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The callback flow has been changed so sessions are now stored in the backend cac
 * [`PowAssent.Plug`] Added `PowAssent.Plug.change_user/4`
 * [`PowAssent.Operations`] Added `PowAssent.Operations.user_identity_changeset/4`
 * [`PowAssent.Phoenix.AuthorizationController`] Now prevents user enumeration attack using `PowEmailConfirmation.Phoenix.ControllerCallbacks` when `PowEmailConfirmation` extension is enabled
+* [`PowAssent.Phoenix.AuthorizationController`] Now stores `:changeset` in session when redirecting to `:add_user_id` page
 [`PowAssent.Phoenix.RegistrationController`] Now prevents user enumeration attack using `PowEmailConfirmation.Phoenix.ControllerCallbacks` when `PowEmailConfirmation` extension is enabled
+* [`PowAssent.Phoenix.RegistrationController`] Now uses `:changeset` stored in the session when rendering `:add_user_id` page
 * [`PowAssent.Plug`] Moved business logic away from `PowAssent.Phoenix.AuthorizationController` into `PowAssent.Plug.callback_upsert/4` that will authenticate, upsert user identity, or create user
 * [`PowAssent.Store.Session`] Added session store module
 * [`PowAssent.Plug`] Added `PowAssent.Plug.init_session/1`

--- a/lib/pow_assent/phoenix/controllers/authorization_controller.ex
+++ b/lib/pow_assent/phoenix/controllers/authorization_controller.ex
@@ -70,13 +70,14 @@ defmodule PowAssent.Phoenix.AuthorizationController do
     |> put_flash(:error, extension_messages(conn).account_already_bound_to_other_user(conn))
     |> redirect(to: routes(conn).session_path(conn, :new))
   end
-  def respond_callback({:error, %{private: %{pow_assent_callback_error: {:invalid_user_id_field, _changeset}}} = conn}) do
+  def respond_callback({:error, %{private: %{pow_assent_callback_error: {:invalid_user_id_field, changeset}}} = conn}) do
     trigger_registration_email_confirmation_controller_callback(conn, fn conn ->
       params   = Map.fetch!(conn.private, :pow_assent_callback_params)
       provider = Map.fetch!(conn.params, "provider")
 
       conn
       |> Plug.put_session(:callback_params, %{provider => params})
+      |> Plug.put_session(:changeset, changeset)
       |> redirect(to: routes(conn).path_for(conn, RegistrationController, :add_user_id, [provider]))
     end)
   end

--- a/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
@@ -163,6 +163,8 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => ""}
       refute get_pow_assent_session(conn, :session_params)
+      assert get_pow_assent_session(conn, :callback_params)
+      assert get_pow_assent_session(conn, :changeset)
     end
 
     test "when identity doesn't exist and and user id taken by other user", %{conn: conn, bypass: bypass} do
@@ -176,6 +178,8 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => "taken@example.com"}
       refute get_pow_assent_session(conn, :session_params)
+      assert get_pow_assent_session(conn, :callback_params)
+      assert get_pow_assent_session(conn, :changeset)
     end
 
     test "with stored request_path assigns to conn", %{conn: conn, bypass: bypass} do
@@ -278,6 +282,8 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => "taken@example.com", "email_verified" => true}
       refute get_pow_assent_session(conn, :session_params)
+      assert get_pow_assent_session(conn, :callback_params)
+      assert get_pow_assent_session(conn, :changeset)
     end
 
     test "when user exists with unconfirmed e-mail", %{conn: conn, bypass: bypass} do


### PR DESCRIPTION
Supersedes #114

Resolves https://github.com/pow-auth/pow_assent/issues/113#issuecomment-562920929

With #135 it's possible to store a lot more in the session as it's no longer limited by the default `Plug.Session` cookie store. So now we just store the whole changeset in the session and loads it when rendering `:add_user_id` page. The changeset errors will show what's wrong.