### PR TITLE
Test cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-elixir: 1.8
+elixir: 1.10
 otp_release: 22.0
 services:
   - postgresql

--- a/test/pow_assent/config_test.exs
+++ b/test/pow_assent/config_test.exs
@@ -25,8 +25,8 @@ defmodule PowAssent.ConfigTest do
       Config.get_provider_config([], :non_existent)
     end
 
-    assert Config.get_provider_config([http_adapter: HTTPAdapater, json_adapter: JSONAdapter, jwt_adapter: JWTAdapter], :provider1) ==
-      [http_adapter: HTTPAdapater, json_adapter: JSONAdapter, jwt_adapter: JWTAdapter, a: 1]
+    assert Config.get_provider_config([http_adapter: HTTPAdapter, json_adapter: JSONAdapter, jwt_adapter: JWTAdapter], :provider1) ==
+      [http_adapter: HTTPAdapter, json_adapter: JSONAdapter, jwt_adapter: JWTAdapter, a: 1]
   end
 
   test "get_provider_config/2 with binary provider" do

--- a/test/support/test_provider.ex
+++ b/test/support/test_provider.ex
@@ -34,9 +34,11 @@ defmodule PowAssent.Test.TestProvider do
           client_id: "client_id",
           client_secret: "abc123",
           site: "http://localhost:#{bypass.port}",
-          strategy: __MODULE__
+          strategy: __MODULE__,
         ], config)
-      ]
+      ],
+      # We suppress the SSL warnings here as Bypass doesn't support SSL
+      http_adapter: {Assent.HTTPAdapter.Httpc, ssl: [verify_fun: :ok]}
     )
   end
 end


### PR DESCRIPTION
Update travis test with Elixir `1.10.0` and remove missing SSL warnings in test.