### PR TITLE
Accept block for link generator helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Updated Pow requirement to `~> 1.0.19`.
 
+### Enhancements
+
+* [`PowAssent.Phoenix.ViewHelpers`] `PowAssent.Phoenix.ViewHelpers.authorization_link/3` now accepts block argument
+* [`PowAssent.Phoenix.ViewHelpers`] `PowAssent.Phoenix.ViewHelpers.deauthorization_link/3` now accepts block argument
+
 ## v0.4.6 (2020-02-16)
 
 The callback flow has been changed so sessions are now stored in the backend cache with `PowAssent.Store.SessionCache` instead of using `Plug.Session`. This prevents exposure of sensitive data, as the only thing stored in the Plug session is a random UUID.

--- a/lib/pow_assent/phoenix/views/view_helpers.ex
+++ b/lib/pow_assent/phoenix/views/view_helpers.ex
@@ -37,15 +37,24 @@ defmodule PowAssent.Phoenix.ViewHelpers do
   `:invited_user` is assigned to the conn, the invitation token will be passed
   on through the URL query params.
   """
-  @spec authorization_link(Conn.t(), atom(), keyword()) :: HTML.safe()
-  def authorization_link(conn, provider, opts \\ []) do
+  @spec authorization_link(Conn.t(), atom(), keyword(), keyword()) :: HTML.safe()
+  def authorization_link(conn, provider, opts \\ [])
+  def authorization_link(conn, provider, do: contents),
+    do: authorization_link(conn, provider, contents, [])
+  def authorization_link(conn, provider, opts) do
+    msg = AuthorizationController.extension_messages(conn).login_with_provider(%{conn | params: %{"provider" => provider}})
+
+    authorization_link(conn, provider, msg, opts)
+  end
+  def authorization_link(conn, provider, opts, do: contents),
+    do: authorization_link(conn, provider, contents, opts)
+  def authorization_link(conn, provider, contents, opts) do
     query_params = invitation_token_query_params(conn) ++ request_path_query_params(conn)
 
-    msg  = AuthorizationController.extension_messages(conn).login_with_provider(%{conn | params: %{"provider" => provider}})
     path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :new, [provider], query_params)
     opts = Keyword.merge(opts, to: path)
 
-    Link.link(msg, opts)
+    Link.link(contents, opts)
   end
 
   defp invitation_token_query_params(%{assigns: %{invited_user: %{invitation_token: token}}}), do: [invitation_token: token]
@@ -60,11 +69,20 @@ defmodule PowAssent.Phoenix.ViewHelpers do
   The link is used to remove authorization with the provider.
   """
   @spec deauthorization_link(Conn.t(), atom(), keyword()) :: HTML.safe()
-  def deauthorization_link(conn, provider, opts \\ []) do
-    msg  = AuthorizationController.extension_messages(conn).remove_provider_authentication(%{conn | params: %{"provider" => provider}})
+  def deauthorization_link(conn, provider, opts \\ [])
+  def deauthorization_link(conn, provider, do: contents),
+    do: deauthorization_link(conn, provider, contents, [])
+  def deauthorization_link(conn, provider, opts) do
+    msg = AuthorizationController.extension_messages(conn).remove_provider_authentication(%{conn | params: %{"provider" => provider}})
+
+    deauthorization_link(conn, provider, msg, opts)
+  end
+  def deauthorization_link(conn, provider, opts, do: contents),
+    do: authorization_link(conn, provider, contents, opts)
+  def deauthorization_link(conn, provider, contents, opts) do
     path = AuthorizationController.routes(conn).path_for(conn, AuthorizationController, :delete, [provider])
     opts = Keyword.merge(opts, to: path, method: :delete)
 
-    Link.link(msg, opts)
+    Link.link(contents, opts)
   end
 end

--- a/test/pow_assent/phoenix/views/view_helpers_test.exs
+++ b/test/pow_assent/phoenix/views/view_helpers_test.exs
@@ -1,4 +1,4 @@
-defmodule PowAssent.ViewHelpersTest do
+defmodule PowAssent.Phoenix.ViewHelpersTest do
   use PowAssent.Test.Phoenix.ConnCase
 
   alias Plug.Conn
@@ -56,5 +56,33 @@ defmodule PowAssent.ViewHelpersTest do
 
     [safe: iodata] = ViewHelpers.provider_links(conn)
     assert {:safe, iodata} == Link.link("Sign in with Test provider", to: "/auth/test_provider/new?invitation_token=token")
+  end
+
+  test "authorization_link/4 accepts blocks", %{conn: conn} do
+    {:safe, iodata} = ViewHelpers.authorization_link(conn, :test_provider) do
+      "Provider auth"
+    end
+
+    assert {:safe, iodata} == Link.link("Provider auth", to: "/auth/test_provider/new")
+
+    {:safe, iodata} = ViewHelpers.authorization_link(conn, :test_provider, class: "example") do
+      "Provider auth"
+    end
+
+    assert {:safe, iodata} == Link.link("Provider auth", to: "/auth/test_provider/new", class: "example")
+  end
+
+  test "deauthorization_link/4 accepts blocks", %{conn: conn} do
+    {:safe, iodata} = ViewHelpers.authorization_link(conn, :test_provider) do
+      "Provider remove"
+    end
+
+    assert {:safe, iodata} == Link.link("Provider remove", to: "/auth/test_provider/new")
+
+    {:safe, iodata} = ViewHelpers.authorization_link(conn, :test_provider, class: "example") do
+      "Provider remove"
+    end
+
+    assert {:safe, iodata} == Link.link("Provider remove", to: "/auth/test_provider/new", class: "example")
   end
 end


### PR DESCRIPTION
Resolves #151 

Since do block runs before it's passed to the method there is no way of rewriting `PowAssent.Phoenix.ViewHelpers.provider_links/2`. I don't know if this is the right approach. My general feeling is that this should be solved with pure CSS, or writing out the provider links logic manually.

The view helpers provider very little extra functionality, so it might be best to just direct devs to write them out in their own view modules.