### PR TITLE
Add helper method to dynamically update provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * [`PowAssent.Plug`] Now calls create session callbacks set with `PowAssent.Plug.put_create_session_callback/2` when a session is created
 * [`PowAssent.Plug.Reauthorization`] Added plug to enable reauthorization
 * [`PowAssent.Phoenix.AuthorizationController`] Now instead of raising an exception for strategy errors, the user is redirected to the sign in page with a generic error message
+* [`PowAssent.Config`] Added `PowAssent.Config.merge_provider_config/3`
+* [`PowAssent.Plug`] Added `PowAssent.Plug.merge_provider_config/3`
+
 
 ## v0.4.7 (2020-04-22)
 

--- a/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
@@ -30,7 +30,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
     test "redirects to authorization url", %{conn: conn, bypass: bypass} do
       conn = get conn, Routes.pow_assent_authorization_path(conn, :new, @provider)
 
-      assert redirected_to(conn) =~ "http://localhost:#{bypass.port}/oauth/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%2Fauth%2Ftest_provider%2Fcallback&response_type=code&state="
+      assert redirected_to(conn) =~ "http://localhost:#{bypass.port}/oauth/authorize?client_id=client_id&"
       assert conn.private[:plug_session]["pow_assent_session"]
       assert get_pow_assent_session(conn, :session_params)[:state]
     end

--- a/test/support/test_provider.ex
+++ b/test/support/test_provider.ex
@@ -8,7 +8,10 @@ defmodule PowAssent.Test.TestProvider do
       site: "http://localhost:4000/",
       authorize_url: "/oauth/authorize",
       token_url: "/oauth/token",
-      user_url: "/api/user"
+      user_url: "/api/user",
+      authorization_params: [
+        scope: "user:read user:write"
+      ]
     ]
   end
 
@@ -34,7 +37,7 @@ defmodule PowAssent.Test.TestProvider do
           client_id: "client_id",
           client_secret: "abc123",
           site: "http://localhost:#{bypass.port}",
-          strategy: __MODULE__,
+          strategy: __MODULE__
         ], config)
       ],
       # We suppress the SSL warnings here as Bypass doesn't support SSL


### PR DESCRIPTION
Resolves https://github.com/pow-auth/pow_assent/issues/117#issuecomment-571837184

Now the plug in the above issue can be reduced to just this:

```elixir
defmodule MyAppWeb.PowAssent.UpdateProviderConfig do
  def init(opts), do: opts

  def call(conn, _opts) do
    updated_config = [authorization_params: [domain: conn.params["domain"]]]

    PowAssent.Plug.merge_provider_config(conn, :auth0, updated_config)
  end
end
```

The config will be deep merged. I'm not sure if this is the proper behavior instead of overriding the config values. ~~It should probably also merge with default config in the provider.~~