### PR TITLE
Redirect the user to sign in instead of raising an exception for strategy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [`PowAssent.Plug`] Added `PowAssent.Plug.fetch_config/1`
 * [`PowAssent.Plug`] Now calls create session callbacks set with `PowAssent.Plug.put_create_session_callback/2` when a session is created
 * [`PowAssent.Plug.Reauthorization`] Added plug to enable reauthorization
+* [`PowAssent.Phoenix.AuthorizationController`] Now instead of raising an exception for strategy errors, the user is redirected to the sign in page with a generic error message
 
 ## v0.4.7 (2020-04-22)
 


### PR DESCRIPTION
Resolves #169

The user is redirected to the sign in page with a generic message, and the error is logged.