### PR TITLE
Use cookie instead of plug session to prevent SameSite policy issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.9 (TBA)
+
+* [`PowAssent.Plug`] Now stores a session cookie instead of using `Plug.Session` to prevent SameSite policy issue in `form_post` flow
+
 ## v0.4.8 (2020-05-18)
 
 ### Enhancements

--- a/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/authorization_controller_test.exs
@@ -31,14 +31,14 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = get conn, Routes.pow_assent_authorization_path(conn, :new, @provider)
 
       assert redirected_to(conn) =~ "http://localhost:#{bypass.port}/oauth/authorize?client_id=client_id&"
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert get_pow_assent_session(conn, :session_params)[:state]
     end
 
     test "redirects with stored request_path", %{conn: conn} do
       conn = get(conn, Routes.pow_assent_authorization_path(conn, :new, @provider, request_path: "/custom-uri"))
 
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert get_pow_assent_session(conn, :request_path) == "/custom-uri"
     end
 
@@ -47,7 +47,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
       conn = get conn, Routes.pow_assent_authorization_path(conn, :new, @provider, invitation_token: signed_token)
 
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert get_pow_assent_session(conn, :invitation_token) == signed_token
     end
 
@@ -59,7 +59,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
         assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
         assert get_flash(conn, :error) == "Something went wrong, and you couldn't be signed in. Please try again."
-        refute conn.private[:plug_session]["pow_assent_session"]
+        refute conn.resp_cookies["pow_assent_auth_session"]
         refute get_pow_assent_session(conn, :session_params)
       end) =~ "Strategy failed with error: \"fail\""
     end
@@ -86,7 +86,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
         assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
         assert get_flash(conn, :error) == "Something went wrong, and you couldn't be signed in. Please try again."
-        refute conn.private[:plug_session]["pow_assent_session"]
+        refute conn.resp_cookies["pow_assent_auth_session"]
         refute get_pow_assent_session(conn, :session_params)
       end) =~ "Strategy failed with error: %Assent.RequestError{error: :invalid_server_response, message: \"Server responded with status: 401"
     end
@@ -99,7 +99,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
         assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
         assert get_flash(conn, :error) == "Something went wrong, and you couldn't be signed in. Please try again."
-        refute conn.private[:plug_session]["pow_assent_session"]
+        refute conn.resp_cookies["pow_assent_auth_session"]
         refute get_pow_assent_session(conn, :session_params)
       end) =~ "Strategy failed with error: %Assent.RequestError{error: :unreachable, message: \"Server was unreachable with Assent.HTTPAdapter.Httpc."
     end
@@ -110,7 +110,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
         assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
         assert get_flash(conn, :error) == "Something went wrong, and you couldn't be signed in. Please try again."
-        refute conn.private[:plug_session]["pow_assent_session"]
+        refute conn.resp_cookies["pow_assent_auth_session"]
         refute get_pow_assent_session(conn, :session_params)
       end) =~ "Strategy failed with error: %Assent.CallbackCSRFError{message: \"CSRF detected with param key \\\"state\\\"\"}"
     end
@@ -122,7 +122,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
       assert redirected_to(conn) == "/session_created"
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
 
@@ -136,7 +136,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
       assert redirected_to(conn) == "/session_created"
       assert get_flash(conn, :info) == "signed_in_test_provider"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
 
@@ -150,7 +150,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :error) == "The Test provider account is already bound to another user."
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
 
@@ -164,7 +164,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert [user_identity] = user.user_identities
       assert user_identity.uid == "new_user"
       assert user_identity.provider == "test_provider"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
 
@@ -175,7 +175,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
       assert get_flash(conn, :error) == "Something went wrong, and you couldn't be signed in. Please try again."
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
 
@@ -185,7 +185,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = get conn, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params)
 
       assert redirected_to(conn) == Routes.pow_assent_registration_path(conn, :add_user_id, "test_provider")
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert %{"test_provider" => %{user_identity: user_identity, user: user}} = get_pow_assent_session(conn, :callback_params)
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => ""}
@@ -200,7 +200,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = get conn, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params)
 
       assert redirected_to(conn) == Routes.pow_assent_registration_path(conn, :add_user_id, "test_provider")
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert %{"test_provider" => %{user_identity: user_identity, user: user}} = get_pow_assent_session(conn, :callback_params)
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => "taken@example.com"}
@@ -218,7 +218,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
         |> get(Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params))
 
       assert redirected_to(conn) == "/custom-uri"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :request_path)
     end
   end
@@ -245,7 +245,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert [user_identity] = user.user_identities
       assert user_identity.uid == "new_user"
       assert user_identity.provider == "test_provider"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
   end
@@ -285,7 +285,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert redirected_to(conn) == "/registration_created"
       assert user = Pow.Plug.current_user(conn)
       assert user.email_confirmed_at
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
     end
 
@@ -308,7 +308,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = Phoenix.ConnTest.dispatch(conn, EmailConfirmationEndpoint, :get, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params))
 
       assert redirected_to(conn) == Routes.pow_assent_registration_path(conn, :add_user_id, "test_provider")
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert %{"test_provider" => %{user_identity: user_identity, user: user}} = get_pow_assent_session(conn, :callback_params)
       assert user_identity == %{"provider" => "test_provider", "uid" => "new_user", "token" => %{"access_token" => "access_token"}}
       assert user == %{"name" => "John Doe", "email" => "taken@example.com", "email_verified" => true}
@@ -349,7 +349,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       assert get_flash(conn, :info) == "signed_in_test_provider"
       assert user = Pow.Plug.current_user(conn)
       assert user.invitation_token == "token"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :invitation_token)
       refute get_pow_assent_session(conn, :session_params)
     end
@@ -368,7 +368,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
         |> Phoenix.ConnTest.dispatch(NoRegistrationEndpoint, :get, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params))
 
       refute Pow.Plug.current_user(conn)
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
 
       assert redirected_to(conn) == Routes.pow_session_path(conn, :new)
@@ -403,7 +403,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = Phoenix.ConnTest.dispatch(conn, WithAccessTokenEndpoint, :get, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params))
 
       assert redirected_to(conn) == "/registration_created"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
       assert user = Pow.Plug.current_user(conn)
       assert [user_identity] = user.user_identities
@@ -416,7 +416,7 @@ defmodule PowAssent.Phoenix.AuthorizationControllerTest do
       conn = Phoenix.ConnTest.dispatch(conn, WithAccessTokenEndpoint, :get, Routes.pow_assent_authorization_path(conn, :callback, @provider, @callback_params))
 
       assert redirected_to(conn) == "/session_created"
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute get_pow_assent_session(conn, :session_params)
       assert Pow.Plug.current_user(conn)
     end

--- a/test/pow_assent/phoenix/controllers/registration_controller_test.exs
+++ b/test/pow_assent/phoenix/controllers/registration_controller_test.exs
@@ -21,7 +21,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
         |> Conn.put_private(:pow_assent_session, nil)
         |> get(Routes.pow_assent_registration_path(conn, :add_user_id, @provider))
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       assert redirected_to(conn) == "/logged-out"
       assert get_flash(conn, :error) == "Invalid Request."
     end
@@ -29,7 +29,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with invalid provider path", %{conn: conn} do
       conn = get conn, Routes.pow_assent_registration_path(conn, :add_user_id, "invalid")
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       assert redirected_to(conn) == "/logged-out"
       assert get_flash(conn, :error) == "Invalid Request."
     end
@@ -37,7 +37,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "shows", %{conn: conn} do
       conn = get conn, Routes.pow_assent_registration_path(conn, :add_user_id, @provider)
 
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert conn.private[:pow_assent_session][:callback_params] == provider_params()
       assert html = html_response(conn, 200)
       assert html =~ "<label for=\"user_email\">Email</label>"
@@ -51,7 +51,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
         |> Conn.put_private(:pow_assent_session, %{changeset: changeset, callback_params: provider_params()})
         |> get(Routes.pow_assent_registration_path(conn, :add_user_id, @provider))
 
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert conn.private[:pow_assent_session][:callback_params] == provider_params()
       refute conn.private[:pow_assent_session][:changeset]
       assert html = html_response(conn, 200)
@@ -71,7 +71,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
         |> Conn.put_private(:pow_assent_session, nil)
         |> post(Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute conn.private[:pow_assent_session][:callback_params]
       assert redirected_to(conn) == "/logged-out"
       assert get_flash(conn, :error) == "Invalid Request."
@@ -80,7 +80,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with valid params", %{conn: conn} do
       conn = post conn, Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute conn.private[:pow_assent_session][:callback_params]
       assert redirected_to(conn) == "/registration_created"
       assert user = Pow.Plug.current_user(conn)
@@ -91,7 +91,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with taken user id params", %{conn: conn} do
       conn = post conn, Routes.pow_assent_registration_path(conn, :create, @provider), @taken_params
 
-      assert conn.private[:plug_session]["pow_assent_session"]
+      assert conn.resp_cookies["pow_assent_auth_session"]
       assert conn.private[:pow_assent_session][:callback_params] == provider_params()
       assert html = html_response(conn, 200)
       assert html =~ "<label for=\"user_email\">Email</label>"
@@ -106,7 +106,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
         |> Conn.put_private(:pow_assent_session, %{callback_params: params})
         |> post(Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute conn.private[:pow_assent_session][:callback_params]
       assert redirected_to(conn) == Routes.pow_registration_path(conn, :new)
       assert get_flash(conn, :error) == "The Test provider account is already bound to another user."
@@ -122,7 +122,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with email from user", %{conn: conn} do
       conn = Phoenix.ConnTest.dispatch(conn, EmailConfirmationEndpoint, :post, Routes.pow_assent_registration_path(conn, :create, @provider), @valid_params)
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute conn.private[:pow_assent_session][:callback_params]
 
       refute Pow.Plug.current_user(conn)
@@ -142,7 +142,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "with taken email", %{conn: conn} do
       conn = Phoenix.ConnTest.dispatch(conn, EmailConfirmationEndpoint, :post, Routes.pow_assent_registration_path(conn, :create, @provider), @taken_params)
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute conn.private[:pow_assent_session][:callback_params]
 
       refute Pow.Plug.current_user(conn)
@@ -159,7 +159,7 @@ defmodule PowAssent.Phoenix.RegistrationControllerTest do
     test "records", %{conn: conn} do
       conn = Phoenix.ConnTest.dispatch(conn, WithAccessTokenEndpoint, :post, Routes.pow_assent_registration_path(conn, :create, @provider), %{user: %{email: "foo@example.com"}})
 
-      refute conn.private[:plug_session]["pow_assent_session"]
+      refute conn.resp_cookies["pow_assent_auth_session"]
       refute conn.private[:pow_assent_session][:callback_params]
 
       assert redirected_to(conn) == "/registration_created"


### PR DESCRIPTION
This PR resolves an issue where the plug session cookie has a SameSite policy. When using `form_post` method, and setting the plug session cookie with SameSite policy the cookie can't be loaded on POST as the POST comes from another domain. Instead of using plug session, this will not set a separate session cookie for PowAssent auth sessions.