### PR TITLE
Better changeset error handling

### DIFF
--- a/lib/pow_assent/ecto/user_identities/context.ex
+++ b/lib/pow_assent/ecto/user_identities/context.ex
@@ -157,7 +157,7 @@ defmodule PowAssent.Ecto.UserIdentities.Context do
   end
 
   defp user_identity_bound_different_user_error({:error, %{errors: errors} = changeset}) do
-    case unique_constraint_error?(errors, :uid_provider) do
+    case unique_constraint_error?(errors, :uid) do
       true  -> {:error, {:bound_to_different_user, changeset}}
       false -> {:error, changeset}
     end
@@ -214,7 +214,7 @@ defmodule PowAssent.Ecto.UserIdentities.Context do
   end
 
   defp user_user_identity_bound_different_user_error({:error, %{changes: %{user_identities: [%{errors: errors}]}} = changeset}) do
-    case unique_constraint_error?(errors, :uid_provider) do
+    case unique_constraint_error?(errors, :uid) do
       true  -> {:error, {:bound_to_different_user, changeset}}
       false -> {:error, changeset}
     end

--- a/lib/pow_assent/ecto/user_identities/schema.ex
+++ b/lib/pow_assent/ecto/user_identities/schema.ex
@@ -106,7 +106,7 @@ defmodule PowAssent.Ecto.UserIdentities.Schema do
     |> Changeset.cast(params, [:provider, :uid, :user_id])
     |> Changeset.validate_required([:provider, :uid])
     |> Changeset.assoc_constraint(:user)
-    |> Changeset.unique_constraint(:uid_provider, name: :user_identities_uid_provider_index)
+    |> Changeset.unique_constraint([:uid, :provider], match: :suffix)
   end
 
   @spec raise_no_user_error :: no_return

--- a/test/pow_assent/ecto/schema_test.exs
+++ b/test/pow_assent/ecto/schema_test.exs
@@ -58,7 +58,7 @@ defmodule PowAssent.Ecto.SchemaTest do
         |> Repo.insert()
 
       assert [user_identity] = changeset.changes.user_identities
-      assert user_identity.errors[:uid_provider] == {"has already been taken", [constraint: :unique, constraint_name: "user_identities_uid_provider_index"]}
+      assert user_identity.errors[:uid] == {"has already been taken", [constraint: :unique, constraint_name: "user_identities_uid_provider_index"]}
     end
 
     test "uses case insensitive value for user id" do

--- a/test/pow_assent/ecto/user_identities/schema_test.exs
+++ b/test/pow_assent/ecto/user_identities/schema_test.exs
@@ -61,7 +61,7 @@ defmodule PowAssent.Ecto.UserIdentities.SchemaTest do
         |> UserIdentity.changeset(@valid_params)
         |> Repo.insert()
 
-      assert changeset.errors[:uid_provider] == {"has already been taken", [constraint: :unique, constraint_name: "user_identities_uid_provider_index"]}
+      assert changeset.errors[:uid] == {"has already been taken", [constraint: :unique, constraint_name: "user_identities_uid_provider_index"]}
     end
   end
 end

--- a/test/support/repo_mock.ex
+++ b/test/support/repo_mock.ex
@@ -17,7 +17,7 @@ defmodule PowAssent.Test.RepoMock do
   @spec insert(%{action: any, valid?: boolean}, any) ::
           {:error, %{action: :insert, valid?: false}} | {:ok, %{id: 1}}
   def insert(%{changes: %{provider: "test_provider", uid: "identity_taken"}} = changeset, _opts) do
-    changeset = Ecto.Changeset.add_error(changeset, :uid_provider, "has already been taken", constraint: :unique, constraint_name: "user_identities_uid_provider_index")
+    changeset = Ecto.Changeset.add_error(changeset, :uid, "has already been taken", constraint: :unique, constraint_name: "user_identities_uid_provider_index")
 
     {:error, %{changeset | action: :insert}}
   end
@@ -27,7 +27,7 @@ defmodule PowAssent.Test.RepoMock do
     {:error, %{changeset | action: :insert}}
   end
   def insert(%{valid?: true, changes: %{user_identities: [%{changes: %{provider: "test_provider", uid: "identity_taken"}} = user_identity_changeset]}} = changeset, _opts) do
-    user_identity_changeset = Ecto.Changeset.add_error(user_identity_changeset, :uid_provider, "has already been taken", constraint: :unique, constraint_name: "user_identities_uid_provider_index")
+    user_identity_changeset = Ecto.Changeset.add_error(user_identity_changeset, :uid, "has already been taken", constraint: :unique, constraint_name: "user_identities_uid_provider_index")
     user_identity_changeset = %{user_identity_changeset | action: :insert}
     changeset               = Ecto.Changeset.put_change(changeset, :user_identities, [user_identity_changeset])
 


### PR DESCRIPTION
Related to #170 this PR attempts to work through better changeset error handling.

The first step was eliminating the `:uid_provider` combination, and just check unique constraint on `:uid`. The second will be to make the changeset error handling more aware of other types of errors when checking for `:bound_to_different_user` or `:invalid_user_id_field`. I'm not sure that returning the tuple is the best way to deal with this.