### PR TITLE
Extract :cache_store_backend from :pow config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10 (TBA)
+
+* [`PowAssent.Plug`] Fixed bug where the `:cache_store_backend` was not being loaded from the application environment correctly
+
 ## v0.4.9 (2020-10-18)
 
 ### Enhancements

--- a/lib/pow_assent/plug.ex
+++ b/lib/pow_assent/plug.ex
@@ -16,6 +16,7 @@ defmodule PowAssent.Plug do
   """
   alias Plug.Conn
   alias PowAssent.{Config, Operations, Store.SessionCache}
+  alias Pow.Config, as: PowConfig
   alias Pow.{Plug, Store.Backend.EtsCache, UUID}
 
   @doc """
@@ -403,7 +404,7 @@ defmodule PowAssent.Plug do
     config = Plug.fetch_config(conn)
 
     config
-    |> Keyword.take([:otp_app, :plug, :repo, :user, :cache_store_backend])
+    |> Keyword.take([:otp_app, :plug, :repo, :user])
     |> Keyword.merge(Keyword.get(config, :pow_assent, []))
   end
 
@@ -521,7 +522,7 @@ defmodule PowAssent.Plug do
   end
 
   defp default_store(pow_config) do
-    backend = Config.get(pow_config, :cache_store_backend, EtsCache)
+    backend = PowConfig.get(pow_config, :cache_store_backend, EtsCache)
 
     {SessionCache, [backend: backend]}
   end

--- a/lib/pow_assent/plug.ex
+++ b/lib/pow_assent/plug.ex
@@ -403,7 +403,7 @@ defmodule PowAssent.Plug do
     config = Plug.fetch_config(conn)
 
     config
-    |> Keyword.take([:otp_app, :plug, :repo, :user])
+    |> Keyword.take([:otp_app, :plug, :repo, :user, :cache_store_backend])
     |> Keyword.merge(Keyword.get(config, :pow_assent, []))
   end
 

--- a/test/pow_assent/plug_test.exs
+++ b/test/pow_assent/plug_test.exs
@@ -358,6 +358,23 @@ defmodule PowAssent.PlugTest do
         secure: true
       }
     end
+
+    test "pulls `:cache_store_backend` from Pow environment config", %{conn: conn} do
+      Application.put_env(:pow_assent, :pow, cache_store_backend: EtsCacheMock)
+
+      pow_config = Keyword.delete(@default_config, :cache_store_backend)
+
+      conn =
+        conn
+        |> Conn.put_private(:pow_config, pow_config)
+        |> Plug.init_session()
+        |> Conn.put_private(:pow_assent_session, %{a: 1})
+        |> Conn.put_private(:pow_assent_session_info, :write)
+        |> Conn.send_resp(200, "")
+
+      assert %{value: id} = conn.resp_cookies["pow_assent_" <> @cookie_key]
+      assert get_from_cache(conn, id) == %{a: 1}
+    end
   end
 
   test "put_session/3", %{conn: conn} do


### PR DESCRIPTION
Pow_assent does its own session handling. In a multi node scenario, if this is not done, the callback could end up in a different node, failing to authenticate.

We could better call out this configuration... or just use the one from Pow. Which probably make sense? not sure, would love to hear what you think or what i am missing here.