### PR TITLE
Fix arity in docs for pow_assent_create_user/3

### DIFF
--- a/lib/pow_assent/ecto/user_identities/context.ex
+++ b/lib/pow_assent/ecto/user_identities/context.ex
@@ -25,7 +25,7 @@ defmodule PowAssent.Ecto.UserIdentities.Context do
 
     * `pow_assent_get_user_by_provider_uid/3`
     * `pow_assent_upsert/2`
-    * `pow_assent_create_user/4`
+    * `pow_assent_create_user/3`
     * `pow_assent_delete/2`
     * `pow_assent_all/1`
 


### PR DESCRIPTION
See https://github.com/pow-auth/pow_assent/blob/master/lib/pow_assent/ecto/user_identities/context.ex#L88
the function pow_assent_create_user has an arity of 3.