### PR TITLE
updating merge_provider_config function typespec

### DIFF
--- a/lib/pow_assent/plug.ex
+++ b/lib/pow_assent/plug.ex
@@ -599,7 +599,7 @@ defmodule PowAssent.Plug do
   config will be set as `:pow_assent` config value for the Pow config for the
   conn with `Pow.Plug.put_config/2`.
   """
-  @spec merge_provider_config(Conn.t(), binary(), Keyword.t()) :: Conn.t()
+  @spec merge_provider_config(Conn.t(), binary() | atom(), Keyword.t()) :: Conn.t()
   def merge_provider_config(conn, provider, new_config) do
     pow_config = Pow.Plug.fetch_config(conn)
     provider   = provider_to_atom!(provider)


### PR DESCRIPTION
This PR updates the `merge_provider_config/3` typespec adding `atom()` as a `provider` typespec. It is breaking on type checks because the provider arg can be a string or atom which is handled [here](https://github.com/pow-auth/pow_assent/blob/master/lib/pow_assent/plug.ex#L433)