### PR TITLE
Fix warning on Elixir 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.11 (TBA)
+
+### Bug fixes
+
+* [`PowAssent.Ecto.UserIdentities.Context`] The macro no longer throws warning in Elixir 1.12
+
 ## v0.4.10 (2020-11-24)
 
 ### Bug fixes

--- a/lib/pow_assent/ecto/user_identities/context.ex
+++ b/lib/pow_assent/ecto/user_identities/context.ex
@@ -99,7 +99,7 @@ defmodule PowAssent.Ecto.UserIdentities.Context do
 
       # TODO: Remove by 0.4.0
       @deprecated "Please use `upsert/2` instead"
-      defdelegate create(user, user_identity_params), to: __MODULE__, as: :upsert
+      def create(user, user_identity_params), do: upsert(user, user_identity_params)
 
       # TODO: Remove by 0.4.0
       @deprecated "Please use `pow_assent_upsert/2` instead"


### PR DESCRIPTION
After compiling a project on Elixir 1.12 then I receive this error:

```elixir
warning: module attribute @impl was not set for function create/2 callback (specified in PowAssent.Ecto.UserIdentities.Context). This either means you forgot to add the "@impl true" annotation before the definition or that you are accidentally overriding this callback
  lib/pulse/accounts/user_identities.ex:3: Pulse.Accounts.UserIdentities (module)
```

I could not find anything mentioned in the changelog  https://github.com/elixir-lang/elixir/blob/v1.12/CHANGELOG.md, that would indicate that [`defdelegate`](https://hexdocs.pm/elixir/Kernel.html#defdelegate/2) would produce this error when used in https://hexdocs.pm/elixir/typespecs.html#behaviours.

/edit

I think I've found the PR that introduced this: https://github.com/elixir-lang/elixir/pull/10682