### PR TITLE
Remove invalid schema attr

### DIFF
--- a/lib/pow_assent/ecto/user_identities/schema.ex
+++ b/lib/pow_assent/ecto/user_identities/schema.ex
@@ -66,8 +66,8 @@ defmodule PowAssent.Ecto.UserIdentities.Schema do
       end)
 
       Enum.each(@pow_assent_fields, fn
-        {name, type, defaults} ->
-          field(name, type, defaults)
+        {name, type} ->
+          field(name, type)
       end)
     end
   end

--- a/lib/pow_assent/ecto/user_identities/schema/fields.ex
+++ b/lib/pow_assent/ecto/user_identities/schema/fields.ex
@@ -10,8 +10,8 @@ defmodule PowAssent.Ecto.UserIdentities.Schema.Fields do
   @spec attrs(Config.t()) :: [tuple()]
   def attrs(_config) do
     [
-      {:provider, :string, null: false},
-      {:uid, :string, null: false}
+      {:provider, :string},
+      {:uid, :string}
     ]
   end
 


### PR DESCRIPTION
On Ecto v3.8.0 I started getting the following error:

```
== Compilation error in file lib/my_app/accounts/user_identity.ex ==
** (ArgumentError) invalid option :null for field/3
    (ecto 3.8.0) lib/ecto/schema.ex:2214: Ecto.Schema.check_options!/3
    (ecto 3.8.0) lib/ecto/schema.ex:1911: Ecto.Schema.__field__/4
    (elixir 1.13.4) lib/enum.ex:937: Enum."-each/2-lists^foreach/1-0-"/2
    lib/my_app/accounts/user_identity.ex:8: (module)
    (elixir 1.13.4) lib/kernel/parallel_compiler.ex:346: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/7
```

Which makes sense because `null` is not a valid attr (seems like it has never been), see https://github.com/elixir-ecto/ecto/blob/4fa2c26dc2064aa2963b96bddee662d18a63e7fd/lib/ecto/schema.ex#L491-L507

I just don't know why it started failing on Ecto v3.8.0 and not on previous versions, but either way seems like that `null: false` should be removed.

Tested on Elixir v1.13.0 and v1.13.4