### PR TITLE
Incorrect error flash message when logging in with no allowed registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [`PowAssent.Plug`] Fixed bug in `callback_upsert/4` where users couldn't sign in with disabled registration
 * `:phoenix` removed from the compilers
 
 ## v0.4.13 (2022-04-27)

--- a/lib/pow_assent/plug.ex
+++ b/lib/pow_assent/plug.ex
@@ -103,6 +103,9 @@ defmodule PowAssent.Plug do
       %{private: %{pow_assent_callback_state: {:ok, _method}}} = conn ->
         {:ok, conn}
 
+      %{private: %{pow_assent_callback_state: {:error, :create_user}, pow_assent_callback_error: nil}} = conn ->
+        {:ok, conn}
+
       conn ->
         {:error, conn}
     end


### PR DESCRIPTION
According to doc, when registration is disabled :
```
If `:pow_assent_registration` in `conn.private` is set to `false` then
  `create_user/4` will not be called and the `:pow_assent_callback_state` set
  to `{:error, :create_user}` with `nil` value for
  `:pow_assent_callback_error`
```

The callback_upsert function should take this case into account and identify this case as nominal and not as error.